### PR TITLE
Fix spec

### DIFF
--- a/spec/api_client_spec.rb
+++ b/spec/api_client_spec.rb
@@ -18,45 +18,45 @@ describe SwaggerClient::ApiClient do
       context 'host' do
         it 'removes http from host' do
           SwaggerClient.configure { |c| c.host = 'http://example.com' }
-          expect(SwaggerClient::Configuration.default.host).to eq('example.com')
+          expect(SwaggerClient::Configuration.default('private').host).to eq('example.com')
         end
 
         it 'removes https from host' do
           SwaggerClient.configure { |c| c.host = 'https://wookiee.com' }
-          expect(SwaggerClient::ApiClient.default.config.host).to eq('wookiee.com')
+          expect(SwaggerClient::ApiClient.default('private').config.host).to eq('wookiee.com')
         end
 
         it 'removes trailing path from host' do
           SwaggerClient.configure { |c| c.host = 'hobo.com/v4' }
-          expect(SwaggerClient::Configuration.default.host).to eq('hobo.com')
+          expect(SwaggerClient::Configuration.default('private').host).to eq('hobo.com')
         end
       end
 
       context 'base_path' do
         it "prepends a slash to base_path" do
           SwaggerClient.configure { |c| c.base_path = 'v4/dog' }
-          expect(SwaggerClient::Configuration.default.base_path).to eq('/v4/dog')
+          expect(SwaggerClient::Configuration.default('private').base_path).to eq('/v4/dog')
         end
 
         it "doesn't prepend a slash if one is already there" do
           SwaggerClient.configure { |c| c.base_path = '/v4/dog' }
-          expect(SwaggerClient::Configuration.default.base_path).to eq('/v4/dog')
+          expect(SwaggerClient::Configuration.default('private').base_path).to eq('/v4/dog')
         end
 
         it "ends up as a blank string if nil" do
           SwaggerClient.configure { |c| c.base_path = nil }
-          expect(SwaggerClient::Configuration.default.base_path).to eq('')
+          expect(SwaggerClient::Configuration.default('private').base_path).to eq('')
         end
       end
     end
   end
 
   describe 'params_encoding in #build_request' do
-    let(:config) { SwaggerClient::Configuration.new }
-    let(:api_client) { SwaggerClient::ApiClient.new(config) }
+    let(:config) { api_client.config }
+    let(:api_client) { SwaggerClient::ApiClient.new('private') }
 
     it 'defaults to nil' do
-      expect(SwaggerClient::Configuration.default.params_encoding).to eq(nil)
+      expect(SwaggerClient::Configuration.default('private').params_encoding).to eq(nil)
       expect(config.params_encoding).to eq(nil)
 
       request = api_client.build_request(:get, '/test')
@@ -71,11 +71,11 @@ describe SwaggerClient::ApiClient do
   end
 
   describe 'timeout in #build_request' do
-    let(:config) { SwaggerClient::Configuration.new }
-    let(:api_client) { SwaggerClient::ApiClient.new(config) }
+    let(:config) { api_client.config }
+    let(:api_client) { SwaggerClient::ApiClient.new('private') }
 
     it 'defaults to 0' do
-      expect(SwaggerClient::Configuration.default.timeout).to eq(0)
+      expect(SwaggerClient::Configuration.default('private').timeout).to eq(0)
       expect(config.timeout).to eq(0)
 
       request = api_client.build_request(:get, '/test')
@@ -91,7 +91,7 @@ describe SwaggerClient::ApiClient do
 
   describe '#deserialize' do
     it "handles Array<Integer>" do
-      api_client = SwaggerClient::ApiClient.new
+      api_client = SwaggerClient::ApiClient.new('private')
       headers = { 'Content-Type' => 'application/json' }
       response = double('response', headers: headers, body: '[12, 34]')
       data = api_client.deserialize(response, 'Array<Integer>')
@@ -100,7 +100,7 @@ describe SwaggerClient::ApiClient do
     end
 
     it 'handles Array<Array<Integer>>' do
-      api_client = SwaggerClient::ApiClient.new
+      api_client = SwaggerClient::ApiClient.new('private')
       headers = { 'Content-Type' => 'application/json' }
       response = double('response', headers: headers, body: '[[12, 34], [56]]')
       data = api_client.deserialize(response, 'Array<Array<Integer>>')
@@ -109,7 +109,7 @@ describe SwaggerClient::ApiClient do
     end
 
     it 'handles Hash<String, String>' do
-      api_client = SwaggerClient::ApiClient.new
+      api_client = SwaggerClient::ApiClient.new('private')
       headers = { 'Content-Type' => 'application/json' }
       response = double('response', headers: headers, body: '{"message": "Hello"}')
       data = api_client.deserialize(response, 'Hash<String, String>')
@@ -121,7 +121,7 @@ describe SwaggerClient::ApiClient do
   describe "#object_to_hash" do
     it 'ignores nils and includes empty arrays' do
       # uncomment below to test object_to_hash for model
-      # api_client = SwaggerClient::ApiClient.new
+      # api_client = SwaggerClient::ApiClient.new('private')
       # _model = SwaggerClient::ModelName.new
       # update the model attribute below
       # _model.id = 1
@@ -133,7 +133,7 @@ describe SwaggerClient::ApiClient do
 
   describe '#build_collection_param' do
     let(:param) { ['aa', 'bb', 'cc'] }
-    let(:api_client) { SwaggerClient::ApiClient.new }
+    let(:api_client) { SwaggerClient::ApiClient.new('private') }
 
     it 'works for csv' do
       expect(api_client.build_collection_param(param, :csv)).to eq('aa,bb,cc')
@@ -161,7 +161,7 @@ describe SwaggerClient::ApiClient do
   end
 
   describe '#json_mime?' do
-    let(:api_client) { SwaggerClient::ApiClient.new }
+    let(:api_client) { SwaggerClient::ApiClient.new('private') }
 
     it 'works' do
       expect(api_client.json_mime?(nil)).to eq false
@@ -178,7 +178,7 @@ describe SwaggerClient::ApiClient do
   end
 
   describe '#select_header_accept' do
-    let(:api_client) { SwaggerClient::ApiClient.new }
+    let(:api_client) { SwaggerClient::ApiClient.new('private') }
 
     it 'works' do
       expect(api_client.select_header_accept(nil)).to be_nil
@@ -194,7 +194,7 @@ describe SwaggerClient::ApiClient do
   end
 
   describe '#select_header_content_type' do
-    let(:api_client) { SwaggerClient::ApiClient.new }
+    let(:api_client) { SwaggerClient::ApiClient.new('private') }
 
     it 'works' do
       expect(api_client.select_header_content_type(nil)).to eq('application/json')
@@ -209,7 +209,7 @@ describe SwaggerClient::ApiClient do
   end
 
   describe '#sanitize_filename' do
-    let(:api_client) { SwaggerClient::ApiClient.new }
+    let(:api_client) { SwaggerClient::ApiClient.new('private') }
 
     it 'works' do
       expect(api_client.sanitize_filename('sun')).to eq('sun')

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -13,7 +13,7 @@ Swagger Codegen version: 2.4.0
 require 'spec_helper'
 
 describe SwaggerClient::Configuration do
-  let(:config) { SwaggerClient::Configuration.default }
+  let(:config) { SwaggerClient::Configuration.default('private') }
 
   before(:each) do
     # uncomment below to setup host and base_path


### PR DESCRIPTION
### After
```
% bundle exec rake
/usr/local/var/rbenv/versions/2.7.0-dev/bin/ruby -I/usr/local/var/rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/rspec-core-3.8.0/lib:/usr/local/var/rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/rspec-support-3.8.0/lib /usr/local/var/rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/rspec-core-3.8.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
....................................................

Finished in 0.01695 seconds (files took 0.23845 seconds to load)
52 examples, 0 failures
```

### Before
```
% bundle exec rake
/usr/local/var/rbenv/versions/2.7.0-dev/bin/ruby -I/usr/local/var/rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/rspec-core-3.8.0/lib:/usr/local/var/rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/rspec-support-3.8.0/lib /usr/local/var/rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/rspec-core-3.8.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
....FFFFFFFFFFFFF.FFFFFFFFFF.F......................

Failures:

  1) SwaggerClient::ApiClient initialization URL stuff host removes http from host
     Failure/Error:
       def self.default(type)
         @@default ||= Configuration.new(type)
       end

     ArgumentError:
       wrong number of arguments (given 0, expected 1)
     # ./lib/swagger_client/configuration.rb:152:in `default'
     # ./spec/api_client_spec.rb:21:in `block (5 levels) in <top (required)>'

  2) SwaggerClient::ApiClient initialization URL stuff host removes https from host
     Failure/Error:
       def self.default(type)
         @@default ||= ApiClient.new(type)
       end

     ArgumentError:
       wrong number of arguments (given 0, expected 1)
     # ./lib/swagger_client/api_client.rb:41:in `default'
     # ./spec/api_client_spec.rb:26:in `block (5 levels) in <top (required)>'

  3) SwaggerClient::ApiClient initialization URL stuff host removes trailing path from host
     Failure/Error:
       def self.default(type)
         @@default ||= Configuration.new(type)
       end

     ArgumentError:
       wrong number of arguments (given 0, expected 1)
     # ./lib/swagger_client/configuration.rb:152:in `default'
     # ./spec/api_client_spec.rb:31:in `block (5 levels) in <top (required)>'

  4) SwaggerClient::ApiClient initialization URL stuff base_path prepends a slash to base_path
     Failure/Error:
       def self.default(type)
         @@default ||= Configuration.new(type)
       end

     ArgumentError:
       wrong number of arguments (given 0, expected 1)
     # ./lib/swagger_client/configuration.rb:152:in `default'
     # ./spec/api_client_spec.rb:38:in `block (5 levels) in <top (required)>'

  5) SwaggerClient::ApiClient initialization URL stuff base_path doesn't prepend a slash if one is already there
     Failure/Error:
       def self.default(type)
         @@default ||= Configuration.new(type)
       end

     ArgumentError:
       wrong number of arguments (given 0, expected 1)
     # ./lib/swagger_client/configuration.rb:152:in `default'
     # ./spec/api_client_spec.rb:43:in `block (5 levels) in <top (required)>'

  6) SwaggerClient::ApiClient initialization URL stuff base_path ends up as a blank string if nil
     Failure/Error:
       def self.default(type)
         @@default ||= Configuration.new(type)
       end

     ArgumentError:
       wrong number of arguments (given 0, expected 1)
     # ./lib/swagger_client/configuration.rb:152:in `default'
     # ./spec/api_client_spec.rb:48:in `block (5 levels) in <top (required)>'

  7) SwaggerClient::ApiClient params_encoding in #build_request defaults to nil
     Failure/Error:
       def self.default(type)
         @@default ||= Configuration.new(type)
       end

     ArgumentError:
       wrong number of arguments (given 0, expected 1)
     # ./lib/swagger_client/configuration.rb:152:in `default'
     # ./spec/api_client_spec.rb:59:in `block (3 levels) in <top (required)>'

  8) SwaggerClient::ApiClient params_encoding in #build_request can be customized
     Failure/Error:
       def initialize(type)
         @scheme = 'https'
         @host = 'stg-api.gmo-aozora.com'
         @base_path = '/ganb/api/' + type + '/v1'
         @api_key = {}
         @api_key_prefix = {}
         @timeout = 0
         @client_side_validation = true
         @verify_ssl = true
         @verify_ssl_host = true

     ArgumentError:
       wrong number of arguments (given 0, expected 1)
     # ./lib/swagger_client/configuration.rb:130:in `initialize'
     # ./spec/api_client_spec.rb:55:in `new'
     # ./spec/api_client_spec.rb:55:in `block (3 levels) in <top (required)>'
     # ./spec/api_client_spec.rb:67:in `block (3 levels) in <top (required)>'

  9) SwaggerClient::ApiClient timeout in #build_request defaults to 0
     Failure/Error:
       def self.default(type)
         @@default ||= Configuration.new(type)
       end

     ArgumentError:
       wrong number of arguments (given 0, expected 1)
     # ./lib/swagger_client/configuration.rb:152:in `default'
     # ./spec/api_client_spec.rb:78:in `block (3 levels) in <top (required)>'

  10) SwaggerClient::ApiClient timeout in #build_request can be customized
      Failure/Error:
        def initialize(type)
          @scheme = 'https'
          @host = 'stg-api.gmo-aozora.com'
          @base_path = '/ganb/api/' + type + '/v1'
          @api_key = {}
          @api_key_prefix = {}
          @timeout = 0
          @client_side_validation = true
          @verify_ssl = true
          @verify_ssl_host = true

      ArgumentError:
        wrong number of arguments (given 0, expected 1)
      # ./lib/swagger_client/configuration.rb:130:in `initialize'
      # ./spec/api_client_spec.rb:74:in `new'
      # ./spec/api_client_spec.rb:74:in `block (3 levels) in <top (required)>'
      # ./spec/api_client_spec.rb:86:in `block (3 levels) in <top (required)>'

  11) SwaggerClient::ApiClient#deserialize handles Array<Integer>
      Failure/Error:
        def initialize(type)
          @config = Configuration.default(type)
          @user_agent = "Swagger-Codegen/#{VERSION}/ruby"
          @default_headers = {
            'Content-Type' => 'application/json',
            'User-Agent' => @user_agent
          }
        end

      ArgumentError:
        wrong number of arguments (given 0, expected 1)
      # ./lib/swagger_client/api_client.rb:32:in `initialize'
      # ./spec/api_client_spec.rb:94:in `new'
      # ./spec/api_client_spec.rb:94:in `block (3 levels) in <top (required)>'

  12) SwaggerClient::ApiClient#deserialize handles Array<Array<Integer>>
      Failure/Error:
        def initialize(type)
          @config = Configuration.default(type)
          @user_agent = "Swagger-Codegen/#{VERSION}/ruby"
          @default_headers = {
            'Content-Type' => 'application/json',
            'User-Agent' => @user_agent
          }
        end

      ArgumentError:
        wrong number of arguments (given 0, expected 1)
      # ./lib/swagger_client/api_client.rb:32:in `initialize'
      # ./spec/api_client_spec.rb:103:in `new'
      # ./spec/api_client_spec.rb:103:in `block (3 levels) in <top (required)>'

  13) SwaggerClient::ApiClient#deserialize handles Hash<String, String>
      Failure/Error:
        def initialize(type)
          @config = Configuration.default(type)
          @user_agent = "Swagger-Codegen/#{VERSION}/ruby"
          @default_headers = {
            'Content-Type' => 'application/json',
            'User-Agent' => @user_agent
          }
        end

      ArgumentError:
        wrong number of arguments (given 0, expected 1)
      # ./lib/swagger_client/api_client.rb:32:in `initialize'
      # ./spec/api_client_spec.rb:112:in `new'
      # ./spec/api_client_spec.rb:112:in `block (3 levels) in <top (required)>'

  14) SwaggerClient::ApiClient#build_collection_param works for csv
      Failure/Error:
        def initialize(type)
          @config = Configuration.default(type)
          @user_agent = "Swagger-Codegen/#{VERSION}/ruby"
          @default_headers = {
            'Content-Type' => 'application/json',
            'User-Agent' => @user_agent
          }
        end

      ArgumentError:
        wrong number of arguments (given 0, expected 1)
      # ./lib/swagger_client/api_client.rb:32:in `initialize'
      # ./spec/api_client_spec.rb:136:in `new'
      # ./spec/api_client_spec.rb:136:in `block (3 levels) in <top (required)>'
      # ./spec/api_client_spec.rb:139:in `block (3 levels) in <top (required)>'

  15) SwaggerClient::ApiClient#build_collection_param works for ssv
      Failure/Error:
        def initialize(type)
          @config = Configuration.default(type)
          @user_agent = "Swagger-Codegen/#{VERSION}/ruby"
          @default_headers = {
            'Content-Type' => 'application/json',
            'User-Agent' => @user_agent
          }
        end

      ArgumentError:
        wrong number of arguments (given 0, expected 1)
      # ./lib/swagger_client/api_client.rb:32:in `initialize'
      # ./spec/api_client_spec.rb:136:in `new'
      # ./spec/api_client_spec.rb:136:in `block (3 levels) in <top (required)>'
      # ./spec/api_client_spec.rb:143:in `block (3 levels) in <top (required)>'

  16) SwaggerClient::ApiClient#build_collection_param works for tsv
      Failure/Error:
        def initialize(type)
          @config = Configuration.default(type)
          @user_agent = "Swagger-Codegen/#{VERSION}/ruby"
          @default_headers = {
            'Content-Type' => 'application/json',
            'User-Agent' => @user_agent
          }
        end

      ArgumentError:
        wrong number of arguments (given 0, expected 1)
      # ./lib/swagger_client/api_client.rb:32:in `initialize'
      # ./spec/api_client_spec.rb:136:in `new'
      # ./spec/api_client_spec.rb:136:in `block (3 levels) in <top (required)>'
      # ./spec/api_client_spec.rb:147:in `block (3 levels) in <top (required)>'

  17) SwaggerClient::ApiClient#build_collection_param works for pipes
      Failure/Error:
        def initialize(type)
          @config = Configuration.default(type)
          @user_agent = "Swagger-Codegen/#{VERSION}/ruby"
          @default_headers = {
            'Content-Type' => 'application/json',
            'User-Agent' => @user_agent
          }
        end

      ArgumentError:
        wrong number of arguments (given 0, expected 1)
      # ./lib/swagger_client/api_client.rb:32:in `initialize'
      # ./spec/api_client_spec.rb:136:in `new'
      # ./spec/api_client_spec.rb:136:in `block (3 levels) in <top (required)>'
      # ./spec/api_client_spec.rb:151:in `block (3 levels) in <top (required)>'

  18) SwaggerClient::ApiClient#build_collection_param works for multi
      Failure/Error:
        def initialize(type)
          @config = Configuration.default(type)
          @user_agent = "Swagger-Codegen/#{VERSION}/ruby"
          @default_headers = {
            'Content-Type' => 'application/json',
            'User-Agent' => @user_agent
          }
        end

      ArgumentError:
        wrong number of arguments (given 0, expected 1)
      # ./lib/swagger_client/api_client.rb:32:in `initialize'
      # ./spec/api_client_spec.rb:136:in `new'
      # ./spec/api_client_spec.rb:136:in `block (3 levels) in <top (required)>'
      # ./spec/api_client_spec.rb:155:in `block (3 levels) in <top (required)>'

  19) SwaggerClient::ApiClient#build_collection_param fails for invalid collection format
      Failure/Error: expect(proc { api_client.build_collection_param(param, :INVALID) }).to raise_error(RuntimeError, 'unknown collection format: :INVALID')

        expected RuntimeError with "unknown collection format: :INVALID", got #<ArgumentError: wrong number of arguments (given 0, expected 1)> with backtrace:
          # ./lib/swagger_client/api_client.rb:32:in `initialize'
          # ./spec/api_client_spec.rb:136:in `new'
          # ./spec/api_client_spec.rb:136:in `block (3 levels) in <top (required)>'
          # ./spec/api_client_spec.rb:159:in `block (4 levels) in <top (required)>'
          # ./spec/api_client_spec.rb:159:in `block (3 levels) in <top (required)>'
      # ./spec/api_client_spec.rb:159:in `block (3 levels) in <top (required)>'

  20) SwaggerClient::ApiClient#json_mime? works
      Failure/Error:
        def initialize(type)
          @config = Configuration.default(type)
          @user_agent = "Swagger-Codegen/#{VERSION}/ruby"
          @default_headers = {
            'Content-Type' => 'application/json',
            'User-Agent' => @user_agent
          }
        end

      ArgumentError:
        wrong number of arguments (given 0, expected 1)
      # ./lib/swagger_client/api_client.rb:32:in `initialize'
      # ./spec/api_client_spec.rb:164:in `new'
      # ./spec/api_client_spec.rb:164:in `block (3 levels) in <top (required)>'
      # ./spec/api_client_spec.rb:167:in `block (3 levels) in <top (required)>'

  21) SwaggerClient::ApiClient#select_header_accept works
      Failure/Error:
        def initialize(type)
          @config = Configuration.default(type)
          @user_agent = "Swagger-Codegen/#{VERSION}/ruby"
          @default_headers = {
            'Content-Type' => 'application/json',
            'User-Agent' => @user_agent
          }
        end

      ArgumentError:
        wrong number of arguments (given 0, expected 1)
      # ./lib/swagger_client/api_client.rb:32:in `initialize'
      # ./spec/api_client_spec.rb:181:in `new'
      # ./spec/api_client_spec.rb:181:in `block (3 levels) in <top (required)>'
      # ./spec/api_client_spec.rb:184:in `block (3 levels) in <top (required)>'

  22) SwaggerClient::ApiClient#select_header_content_type works
      Failure/Error:
        def initialize(type)
          @config = Configuration.default(type)
          @user_agent = "Swagger-Codegen/#{VERSION}/ruby"
          @default_headers = {
            'Content-Type' => 'application/json',
            'User-Agent' => @user_agent
          }
        end

      ArgumentError:
        wrong number of arguments (given 0, expected 1)
      # ./lib/swagger_client/api_client.rb:32:in `initialize'
      # ./spec/api_client_spec.rb:197:in `new'
      # ./spec/api_client_spec.rb:197:in `block (3 levels) in <top (required)>'
      # ./spec/api_client_spec.rb:200:in `block (3 levels) in <top (required)>'

  23) SwaggerClient::ApiClient#sanitize_filename works
      Failure/Error:
        def initialize(type)
          @config = Configuration.default(type)
          @user_agent = "Swagger-Codegen/#{VERSION}/ruby"
          @default_headers = {
            'Content-Type' => 'application/json',
            'User-Agent' => @user_agent
          }
        end

      ArgumentError:
        wrong number of arguments (given 0, expected 1)
      # ./lib/swagger_client/api_client.rb:32:in `initialize'
      # ./spec/api_client_spec.rb:212:in `new'
      # ./spec/api_client_spec.rb:212:in `block (3 levels) in <top (required)>'
      # ./spec/api_client_spec.rb:215:in `block (3 levels) in <top (required)>'

  24) SwaggerClient::Configuration#base_url should remove trailing slashes
      Failure/Error:
        def self.default(type)
          @@default ||= Configuration.new(type)
        end

      ArgumentError:
        wrong number of arguments (given 0, expected 1)
      # ./lib/swagger_client/configuration.rb:152:in `default'
      # ./spec/configuration_spec.rb:16:in `block (2 levels) in <top (required)>'
      # ./spec/configuration_spec.rb:36:in `block (4 levels) in <top (required)>'
      # ./spec/configuration_spec.rb:35:in `each'
      # ./spec/configuration_spec.rb:35:in `block (3 levels) in <top (required)>'

Finished in 0.02443 seconds (files took 0.30398 seconds to load)
52 examples, 24 failures

Failed examples:

rspec ./spec/api_client_spec.rb:19 # SwaggerClient::ApiClient initialization URL stuff host removes http from host
rspec ./spec/api_client_spec.rb:24 # SwaggerClient::ApiClient initialization URL stuff host removes https from host
rspec ./spec/api_client_spec.rb:29 # SwaggerClient::ApiClient initialization URL stuff host removes trailing path from host
rspec ./spec/api_client_spec.rb:36 # SwaggerClient::ApiClient initialization URL stuff base_path prepends a slash to base_path
rspec ./spec/api_client_spec.rb:41 # SwaggerClient::ApiClient initialization URL stuff base_path doesn't prepend a slash if one is already there
rspec ./spec/api_client_spec.rb:46 # SwaggerClient::ApiClient initialization URL stuff base_path ends up as a blank string if nil
rspec ./spec/api_client_spec.rb:58 # SwaggerClient::ApiClient params_encoding in #build_request defaults to nil
rspec ./spec/api_client_spec.rb:66 # SwaggerClient::ApiClient params_encoding in #build_request can be customized
rspec ./spec/api_client_spec.rb:77 # SwaggerClient::ApiClient timeout in #build_request defaults to 0
rspec ./spec/api_client_spec.rb:85 # SwaggerClient::ApiClient timeout in #build_request can be customized
rspec ./spec/api_client_spec.rb:93 # SwaggerClient::ApiClient#deserialize handles Array<Integer>
rspec ./spec/api_client_spec.rb:102 # SwaggerClient::ApiClient#deserialize handles Array<Array<Integer>>
rspec ./spec/api_client_spec.rb:111 # SwaggerClient::ApiClient#deserialize handles Hash<String, String>
rspec ./spec/api_client_spec.rb:138 # SwaggerClient::ApiClient#build_collection_param works for csv
rspec ./spec/api_client_spec.rb:142 # SwaggerClient::ApiClient#build_collection_param works for ssv
rspec ./spec/api_client_spec.rb:146 # SwaggerClient::ApiClient#build_collection_param works for tsv
rspec ./spec/api_client_spec.rb:150 # SwaggerClient::ApiClient#build_collection_param works for pipes
rspec ./spec/api_client_spec.rb:154 # SwaggerClient::ApiClient#build_collection_param works for multi
rspec ./spec/api_client_spec.rb:158 # SwaggerClient::ApiClient#build_collection_param fails for invalid collection format
rspec ./spec/api_client_spec.rb:166 # SwaggerClient::ApiClient#json_mime? works
rspec ./spec/api_client_spec.rb:183 # SwaggerClient::ApiClient#select_header_accept works
rspec ./spec/api_client_spec.rb:199 # SwaggerClient::ApiClient#select_header_content_type works
rspec ./spec/api_client_spec.rb:214 # SwaggerClient::ApiClient#sanitize_filename works
rspec ./spec/configuration_spec.rb:34 # SwaggerClient::Configuration#base_url should remove trailing slashes
```